### PR TITLE
Validate zone server model before binding to UI

### DIFF
--- a/app/src/main/java/dave/swgemuserverstatus/ServerStatusActivity.java
+++ b/app/src/main/java/dave/swgemuserverstatus/ServerStatusActivity.java
@@ -6,6 +6,7 @@ import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.design.widget.Snackbar;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
@@ -138,6 +139,11 @@ public class ServerStatusActivity extends AppCompatActivity implements
         content.removeAllViews();
 
         for (final ZoneServer zoneServer : zoneServers) {
+            if (!zoneServer.isValid()) {
+                Snackbar.make(content, R.string.error, Snackbar.LENGTH_SHORT);
+                continue;
+            }
+
             final View zoneServerCard =
                     LayoutInflater.from(this).inflate(R.layout.card_zone_server, content, false);
 

--- a/app/src/main/java/dave/swgemuserverstatus/model/ZoneServer.java
+++ b/app/src/main/java/dave/swgemuserverstatus/model/ZoneServer.java
@@ -1,5 +1,7 @@
 package dave.swgemuserverstatus.model;
 
+import android.text.TextUtils;
+
 /**
  * ZoneServer model.
  *
@@ -22,6 +24,10 @@ public class ZoneServer {
         this.users = users;
         this.uptime = uptime;
         this.lastUpdated = lastUpdated;
+    }
+
+    public boolean isValid() {
+        return !TextUtils.isEmpty(name) && !TextUtils.isEmpty(status) && users != null;
     }
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,5 @@
     <string name="app_name">SWGEmu Server Status</string>
     <string name="action_refresh">Refresh</string>
     <string name="preference_file_key">dave.swgemuserverstatus.preference_file_key</string>
+    <string name="error">Oops! Something went wrong..</string>
 </resources>


### PR DESCRIPTION
Addresses two reported NPE's by validating the zone server model before binding it to the UI. Shows an error [snackbar](https://developer.android.com/training/snackbar/action.html) when a zone server is invalid

Interested in what the XML response looks like for invalid zone servers .. future To-do